### PR TITLE
emails: hide popup before setting cookies

### DIFF
--- a/_static/emails.js
+++ b/_static/emails.js
@@ -26,9 +26,6 @@ async function emailButtonClick() {
   let res = await fetch("https://premai.pythonanywhere.com/email?a=" + emailValue);
   const ok = 200 <= res.status && res.status < 299;
   const server_err = 500 <= res.status && res.status < 599;
-  if (ok) {
-    setCookie("address", emailValue, 365);
-  }
   if (ok || server_err) {
     let modal = document.getElementById('email-modal');
     modal.style.display = 'none'
@@ -37,6 +34,9 @@ async function emailButtonClick() {
     let emailError = document.getElementsByClassName('email-error')[0];
     let msg = await res.json();
     emailError.innerHTML = "Error " + res.status + ": " + msg.status;
+  }
+  if (ok) {
+    setCookie("address", emailValue, 365); // might fail if cookies disabled
   }
 }
 

--- a/sdk.md
+++ b/sdk.md
@@ -83,7 +83,7 @@ Overall, LangChain's advanced features enable developers to build advanced langu
 
 ![banner](https://static.premai.io/book/sdk-llama-index.jpg)
 
-LLaMAIndex is a data framework for LLM applications to ingest, structure, and access private or domain-specific data. It provides tools such as data connectors, data indexes, engines (query and chat), and data agents to facilitate natural language access to data. LLaMAIndex is designed for beginners, advanced users, and everyone in between, with a high-level API for easy data ingestion and querying, as well as lower-level APIs for customisation. It can be installed using `pip` and has detailed [documentation](https://gpt-index.readthedocs.io/en/latest) and tutorials for getting started. LLaMAIndex also has associated projects like https://github.com/emptycrown/llama-hub and https://github.com/run-llama/llama-lab.
+LLaMAIndex is a data framework for LLM applications to ingest, structure, and access private or domain-specific data. It provides tools such as data connectors, data indexes, engines (query and chat), and data agents to facilitate natural language access to data. LLaMAIndex is designed for beginners, advanced users, and everyone in between, with a high-level API for easy data ingestion and querying, as well as lower-level APIs for customisation. It can be installed using `pip` and has detailed [documentation](https://gpt-index.readthedocs.io/en/latest) and tutorials for getting started. LLaMAIndex also has associated projects like https://github.com/run-llama/llama-hub and https://github.com/run-llama/llama-lab.
 
 ### Data connectors
 


### PR DESCRIPTION
if users have disabled cookies (i.e. `getCookie` works but `setCookie` errors), this PR might delay the error until *after* the popup is closed.

con: users with cookies disabled will still get re-prompted for an email each time they click on a chapter