### PR TITLE
CI: fix build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -53,6 +53,7 @@ jobs:
     - run: pip install -r requirements.txt
     - name: jupyter-book build
       run: |
+        sudo apt update -qq
         sudo apt install -qq ghostscript fonts-freefont-otf  # https://stackoverflow.com/a/69012150
         sed -ri 's#^(\s*baseurl:).*#\1 ${{ steps.pages.outputs.base_url }}/'$SITE_PREFIX'#g' _config.yml
         jupyter-book build --builder dirhtml --warningiserror --nitpick --keep-going .


### PR DESCRIPTION
- [x] fix `apt install`
- [x] ~fix https://docs.nvidia.com/deeplearning/tensorrt/developer-guide links~
  + maybe pin to archived version https://docs.nvidia.com/deeplearning/tensorrt/archives/tensorrt-861/developer-guide for now?
  + reported in https://github.com/NVIDIA/TensorRT/issues/3396