### PR TITLE
fix links

### DIFF
--- a/desktop-apps.md
+++ b/desktop-apps.md
@@ -208,7 +208,7 @@ koboldcpp Julius Model Configuration
 
 [local.ai]: https://www.localai.app
 
-The [local.ai] App from https://github.com/louisgv/local.ai ([not to be confused](https://github.com/louisgv/local.ai/discussions/71) with [LocalAI](https://localai.io) from https://github.com/go-skynet/LocalAI) is a simple application for loading LLMs after you manually download a `ggml` model from online.
+The [local.ai] App from https://github.com/louisgv/local.ai ([not to be confused](https://github.com/louisgv/local.ai/discussions/71) with [LocalAI](https://localai.io) from https://github.com/mudler/LocalAI) is a simple application for loading LLMs after you manually download a `ggml` model from online.
 
 ### UI and Chat
 

--- a/eval-datasets.md
+++ b/eval-datasets.md
@@ -669,7 +669,7 @@ resolution of 320 × 240 pixels.
 
 #### Kinetics
 
-**[Kinetics](https://www.deepmind.com/open-source/kinetics)**, developed by the Google Research team, is a dataset featuring
+**[Kinetics](https://github.com/google-deepmind/kinetics-i3d)**, developed by the Google Research team, is a dataset featuring
 up to 650,000 video clips, covering 400/600/700 human action classes in different versions. These clips show diverse human
 interactions, including human-object and human-human activities. Each action class contains a minimum of
 [400](https://paperswithcode.com/dataset/kinetics-400-1)/[600](https://paperswithcode.com/dataset/kinetics-600)/[700](https://paperswithcode.com/dataset/kinetics-700)

--- a/models.md
+++ b/models.md
@@ -480,7 +480,7 @@ And currently [its fine-tuned variants](https://huggingface.co/Phind/Phind-CodeL
 
 #### Mistral 7B
 
-[Mistral 7B](https://huggingface.co/mistralai) is released by [Mistral AI](https://mistral.ai), a french startup which recently [raised a good seed round](https://techcrunch.com/2023/06/13/frances-mistral-ai-blows-in-with-a-113m-seed-round-at-a-260m-valuation-to-take-on-openai). The team comprises of ex-[Deepmind](https://www.deepmind.com) and ex-[Meta](https://ai.meta.com) researchers, who worked on [](#llama), Flamingo {cite}`alayrac2022flamingo` and [Chinchilla](https://en.wikipedia.org/wiki/Chinchilla_AI) projects.
+[Mistral 7B](https://huggingface.co/mistralai) is released by [Mistral AI](https://mistral.ai), a french startup which recently [raised a good seed round](https://techcrunch.com/2023/06/13/frances-mistral-ai-blows-in-with-a-113m-seed-round-at-a-260m-valuation-to-take-on-openai). The team comprises of ex-[Deepmind](https://deepmind.google) and ex-[Meta](https://ai.meta.com) researchers, who worked on [](#llama), Flamingo {cite}`alayrac2022flamingo` and [Chinchilla](https://en.wikipedia.org/wiki/Chinchilla_AI) projects.
 
 ##### Uniqueness
 

--- a/sdk.md
+++ b/sdk.md
@@ -9,7 +9,7 @@
 SDK | Use cases | Vector stores | Embedding model | LLM Model | Languages | Features
 ----|-----------|---------------|-----------------|-----------|-----------|----------
 [](#langchain) | Chatbots, prompt chaining, document related tasks | Comprehensive list of data sources available to get connected readily | State of art embedding models in the bucket to choose from | A-Z availability of LLMs out there in the market | Python, Javascript, Typescript | Open source & 1.5k+ contributors strong for active project development
-[](#llama-index) | Connecting multiple data sources to LLMs, document query interface using retrieval augmented generation, advanced chatbots, structured analytics | Wide options to connect & facility to [create a new one](https://gpt-index.readthedocs.io/en/latest/examples/vector_stores/CognitiveSearchIndexDemo.html#create-index-if-it-does-not-exist) | Besides the 3 commonly available models we can use a [custom embedding model](https://gpt-index.readthedocs.io/en/latest/examples/embeddings/custom_embeddings.html) as well | Set of restricted availability of LLM models besides [customised abstractions](https://gpt-index.readthedocs.io/en/latest/core_modules/model_modules/llms/usage_custom.html) suited for your custom data | Python, Javascript, Typescript | Tailor-made for high customisations if not happy with the current parameters and integrations
+[](#llama-index) | Connecting multiple data sources to LLMs, document query interface using retrieval augmented generation, advanced chatbots, structured analytics | Wide options to connect & facility to [create a new one](https://gpt-index.readthedocs.io/en/latest/examples/vector_stores/CognitiveSearchIndexDemo.html#create-index-if-it-does-not-exist) | Besides the 3 commonly available models we can use a [custom embedding model](https://gpt-index.readthedocs.io/en/latest/examples/embeddings/custom_embeddings.html) as well | Set of restricted availability of LLM models besides [customised abstractions](https://gpt-index.readthedocs.io/en/latest/module_guides/models/llms/usage_custom.html) suited for your custom data | Python, Javascript, Typescript | Tailor-made for high customisations if not happy with the current parameters and integrations
 [](#litellm) | Integrating multiple LLMs, evaluating LLMs | Not Applicable | Currently supports only `text-embedding-ada-002` from OpenAI & Azure | Expanding the list of LLM providers with the most commonly used ones ready for use | Python | Lightweight, streaming model response, consistent output response
 ```
 
@@ -87,7 +87,7 @@ LLaMAIndex is a data framework for LLM applications to ingest, structure, and ac
 
 ### Data connectors
 
-[Data connectors](https://gpt-index.readthedocs.io/en/latest/core_modules/data_modules/connector/root.html) are software components that enable the transfer of data between different systems or applications. They provide a way to extract data from a source system, transform it if necessary, and load it into a target system. Data connectors are commonly used in data integration and ETL (Extract, Transform, Load) processes.
+[Data connectors](https://gpt-index.readthedocs.io/en/latest/module_guides/loading/connector/root.html) are software components that enable the transfer of data between different systems or applications. They provide a way to extract data from a source system, transform it if necessary, and load it into a target system. Data connectors are commonly used in data integration and ETL (Extract, Transform, Load) processes.
 
 There are various types of data connectors available, depending on the specific systems or applications they connect to. Some common ones include:
 
@@ -101,7 +101,7 @@ Data connectors play a crucial role in enabling data interoperability and ensuri
 
 ### Data indexes
 
-[Data indexes](https://gpt-index.readthedocs.io/en/latest/core_modules/data_modules/index/root.html) in LLaMAIndex are intermediate representations of data that are structured in a way that is easy and performant for Language Model Models (LLMs) to consume. These indexes are built from documents and serves as the core foundation for retrieval-augmented generation (RAG) use-cases.
+[Data indexes](https://gpt-index.readthedocs.io/en/latest/module_guides/indexing/indexing.html) in LLaMAIndex are intermediate representations of data that are structured in a way that is easy and performant for Language Model Models (LLMs) to consume. These indexes are built from documents and serves as the core foundation for retrieval-augmented generation (RAG) use-cases.
 Under the hood, indexes in LLaMAIndex store data in Node objects, which represent chunks of the original documents. These indexes also expose a Retriever interface that supports additional configuration and automation.
 LLaMAIndex provides several types of indexes, including Vector Store Index, Summary Index, Tree Index, Keyword Table Index, Knowledge Graph Index, and SQL Index. Each index has its own specific use case and functionality.
 


### PR DESCRIPTION
- LocalAI updated repo URL
- "deepmind kinetics" seems to have no working homepage atm
- gpt-index updated docs links