### PR TITLE
mailchimp emails

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -59,7 +59,11 @@ parse:
       {{ '```{committers} ' + env.docname + '.md\n```' }}
 
       <div id="email-modal" class="modal">
-        <div class="modal-content">
+        <iframe name="mailchimp-result" style="display: none;"></iframe>
+        <form
+          action="https://premai.us21.list-manage.com/subscribe/post?u=76d4e3f9cb2c0f0108fb2da88&amp;id=2c17a51111&amp;f_id=0014ede6f0"
+          method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="modal-content"
+          target="mailchimp-result" novalidate="">
           <img src="https://static.premai.io/book/book-cover.jpg" alt="book cover" />
           <div class="modal-text">
             <h1>Enter your email to access this book for free</h1>
@@ -68,16 +72,17 @@ parse:
               (no spam nor giving your email to anyone else).
             </p>
             <div class="input-container">
-              <input type="email" id="email-input" name="email" placeholder="Enter your email..." />
-              <button id="email-submit" onclick="emailButtonClick()">Subscribe</button>
+              <input type="email" id="email-input" name="EMAIL" placeholder="Enter your email..." />
+              <input style="display: none;" type="hidden" name="tags" value="2958019" />
+              <input style="display: none;" type="text" name="b_76d4e3f9cb2c0f0108fb2da88_2c17a51111" tabindex="-1" value="" />
+              <input type="submit" name="subscribe" id="email-submit" class="button" value="Subscribe" onclick="emailButtonClick()" />
             </div>
-            <span class="email-error"></span>
             <p>
               This book is open source; you can also read &amp; contribute at<br />
               <a href="https://github.com/premAI-io/state-of-open-source-ai" target="_blank"><i class="fa-brands fa-github"></i>&nbsp;premAI-io/state-of-open-source-ai</a>.
             </p>
           </div>
-        </div>
+        </form>
       </div>
   myst_enable_extensions: # https://myst-parser.readthedocs.io/en/latest/using/syntax-optional.html
   # needs myst-parser>=0.19 <- https://github.com/executablebooks/MyST-NB/issues/530

--- a/_static/emails.css
+++ b/_static/emails.css
@@ -28,7 +28,7 @@
   .modal-content input {
     font-size: 0.9rem !important;
   }
-  .modal-content button {
+  .modal-content input.button {
     padding: 10px !important;
   }
   .modal-content img {
@@ -75,7 +75,7 @@
   outline: none !important;
 }
 
-.modal-content button {
+.modal-content input.button {
   color: white;
   border: none;
   text-align: center;

--- a/_static/emails.js
+++ b/_static/emails.js
@@ -28,7 +28,7 @@ async function emailButtonClick() {
   const server_err = 500 <= res.status && res.status < 599;
   if (ok || server_err) {
     let modal = document.getElementById('email-modal');
-    modal.style.display = 'none'
+    modal.style.display = 'none';
     emailInput.value = "";
   } else {
     let emailError = document.getElementsByClassName('email-error')[0];


### PR DESCRIPTION
- used a form rather than js `fetch` to circumvent mailchimp's CORS
- discard mailchimp response (render in hidden `iframe`)
- continue using original endpoint for basic validation checks

the above hacks are necessary since (afaik) mailchimp doesn't provides a proper JSON API with configurable CORS, and we don't want to hardcode API keys here. Less hacky solutions are welcome /CC @Janaka-Steph :)