### PR TITLE
Make ONNX Quantisation Support green for “good” (was yellow) [tiny fix]

### DIFF
--- a/model-formats.md
+++ b/model-formats.md
@@ -11,7 +11,7 @@ Integration with Deep Learning Frameworks | 🟢 [most](onnx-support) | 🟡 [gr
 Deployment Tools | 🟢 [yes](onnx-runtime) | 🔴 no | 🟢 [yes](triton-inference)
 Interoperability | 🟢 [yes](onnx-interoperability) | 🔴 no | 🔴 [no](tensorrt-interoperability)
 Inference Boost | 🟡 moderate | 🟢 good | 🟢 good
-Quantisation Support | 🟡 [good](onnx-quantisation) | 🟢 [good](ggml-quantisation) | 🟡 [moderate](tensorrt-quantisation)
+Quantisation Support | 🟢 [good](onnx-quantisation) | 🟢 [good](ggml-quantisation) | 🟡 [moderate](tensorrt-quantisation)
 Custom Layer Support| 🟢 [yes](onnx-custom-layer) | 🔴 limited | 🟢 [yes](tensorrt-custom-layer)
 Maintainer | [LF AI & Data Foundation](https://wiki.lfaidata.foundation) | https://github.com/ggerganov | https://github.com/NVIDIA
 ```


### PR DESCRIPTION
One of the ”good” items (ONNX Quantisation Support) had the yellow dot instead of the 🟢 green. Fixed for clarity.

# Review checklist

> Don't worry about satisfying all items, it's fine to open a (draft) PR.

- [ ] chapter content
  + [ ] only one top-level `# h1-Title`
  + [ ] summary (e.g. table or TL;DR overview), no need for an explicit `## Summary/Introduction` title or equivalent
  + [ ] main content focus: recent developments in open source AI
    + general context/background (brief)
    + current pros/cons
    + in-depth insights (not yet widely known)
  + [ ] likely `## Future` developments
  + [ ] end with `{{ comments }}`
- [ ] appropriate citations
  + [ ] BibTeX references
  + [ ] Glossary terms
  + [ ] cross-references (figures/chapters)
  + [ ] (if `new-chapter.md`), add `_toc.yml` entry & `index.md` table row
  + [ ] If CI URL checks have false-positives, append to `_config.yml:sphinx.config.linkcheck*`
- [ ] images & data not committed to this repo (e.g. use https://github.com/premAI-io/static.premai.io instead)
